### PR TITLE
Exporting all files in SDK for direct access

### DIFF
--- a/vulkan_sdk_linux.BUILD
+++ b/vulkan_sdk_linux.BUILD
@@ -1,5 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
+exports_files(glob(["**/*"]))
+
 alias(
     name = "glslangValidator",
     actual = "bin/glslangValidator",

--- a/vulkan_sdk_macos.BUILD
+++ b/vulkan_sdk_macos.BUILD
@@ -1,5 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
+exports_files(glob(["**/*"]))
+
 alias(
     name = "glslangValidator",
     actual = "bin/glslangValidator",

--- a/vulkan_sdk_windows.BUILD
+++ b/vulkan_sdk_windows.BUILD
@@ -1,5 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
+exports_files(glob(["**/*"]))
+
 alias(
     name = "glslangValidator",
     actual = "Bin/glslangValidator.exe",


### PR DESCRIPTION
potentially closes #3 

This allows all files in the SDK on any platform to be available for users. 