### PR TITLE
chore: update CI to only push

### DIFF
--- a/.github/workflows/bazel_build.yaml
+++ b/.github/workflows/bazel_build.yaml
@@ -1,9 +1,9 @@
 name: Bazel
 
 on:
-  pull_request: {}
-  push: {}
-
+  push:
+    branches:
+      - "**"
 jobs:
   build_and_test_ubuntu20:
     name: Linux Ubuntu 20.04 build <GCC 9.3.0>


### PR DESCRIPTION
pull_request type should be unncessary since push will cover it already. This'll prevent multiple runs of the same job.